### PR TITLE
Replace NaN check

### DIFF
--- a/Assets/Attri/Runtime/AttributeData/Compression/FloatCompressor.cs
+++ b/Assets/Attri/Runtime/AttributeData/Compression/FloatCompressor.cs
@@ -137,7 +137,7 @@ namespace Attri.Runtime
 		
 		static float CompressValue(float value, EncodeParam encodeParam, DecodeParam decodeParam)
 		{
-			if(value is float.NaN) return float.NaN;
+			if(float.IsNaN(value)) return float.NaN;
 			// Encode
 			var M = Encode(value, encodeParam);
 			// Decode


### PR DESCRIPTION
## Summary
- use `float.IsNaN` for NaN detection in `FloatCompressor`

## Testing
- `csc Assets/Attri/Runtime/AttributeData/Compression/FloatCompressor.cs -target:library -out:FloatCompressor.dll` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470d578f108332880af400c6cc115f